### PR TITLE
fix: datePublished and dateModified null replacement fixed

### DIFF
--- a/src/seo.tsx
+++ b/src/seo.tsx
@@ -19,6 +19,8 @@ interface Props {
   dateModified?: string
 }
 
+const dateNow = new Date(Date.now()).toISOString()
+
 export const SEO = ({
   title,
   titleTemplate,
@@ -31,18 +33,14 @@ export const SEO = ({
   siteLocale,
   twitterUsername,
   author = 'J Doe.',
-  datePublished,
-  dateModified,
+  datePublished = dateNow,
+  dateModified = dateNow,
 }: Props) => {
   const seo = {
     title: title.slice(0, 70),
     description: description.slice(0, 160),
-    datePublished: datePublished
-      ? null
-      : new Date(Date.now()).toISOString(),
-    dateModified: dateModified
-      ? null
-      : new Date(Date.now()).toISOString(),
+    datePublished,
+    dateModified,
   }
 
   const copyrightYear = new Date().getFullYear()


### PR DESCRIPTION
Dates datePublished and dateModified were replaced by nulls if they were provided to SEO component.

Example:
![Zrzut ekranu 2020-06-20 o 15 00 15](https://user-images.githubusercontent.com/19781936/85203045-2da4ab00-b30b-11ea-9d86-665ea69a4c4a.png)

